### PR TITLE
Add Google Calendar API integration and example environment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+GEMINI_API_KEY=<template>
+GOOGLE_CREDENTIALS_PATH=<template>

--- a/agentic_workspace/tools/google_calendar/actions.py
+++ b/agentic_workspace/tools/google_calendar/actions.py
@@ -1,0 +1,96 @@
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from typing import Optional, List
+
+from agentic_workspace.tools.google_calendar.auth import get_calendar_credentials
+
+
+# Google Calendar API
+class GoogleCalendar:
+    _instance = None
+    _initialized = False
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(GoogleCalendar, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self, calendar_id: str = 'primary'):
+        if not self._initialized:
+            # Get credentials
+            creds = get_calendar_credentials()
+
+            # Build the Google Calendar API service 
+            self.service = build('calendar', 'v3', credentials=creds)
+            self.calendar_id = calendar_id
+            self._initialized = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.service:
+            self.service.close()
+
+    # Insert event
+    def insert_event(self, event: dict) -> Optional[dict]:
+        try:
+            event = self.service.events().insert(calendarId=self.calendar_id, body=event).execute()
+            return event
+        except HttpError as e:
+            print(f"Error inserting event: {e}")
+            return None
+
+    # List event
+    def list_event(self, timeMin: Optional[str] = None, maxResults: int = 10) -> List[dict]:
+        try:
+            # Call the Calendar API
+            events_result = self.service.events().list(
+                calendarId=self.calendar_id,
+                timeMin=timeMin,
+                maxResults=maxResults,
+                singleEvents=True,
+                orderBy='startTime',
+            ).execute()
+
+            events = events_result.get('items', [])
+            return events
+        except HttpError as e:
+            print(f"Error listing events: {e}")
+            return []
+    
+    # Get event
+    def get_event(self, event_id: str) -> Optional[dict]:
+        try:
+            event = self.service.events().get(calendarId=self.calendar_id, eventId=event_id).execute()
+            return event
+        except HttpError as e:
+            print(f"Error getting event: {e}")
+            return None
+
+    # Update event
+    def update_event(self, event_id: str, event: dict) -> Optional[dict]:
+        try:
+            body = self.get_event(event_id)
+
+            # Update the event
+            for key, value in event.items():
+                body[key] = value
+
+            event = self.service.events().update(calendarId=self.calendar_id, eventId=event_id, body=body).execute()
+            return event
+        except HttpError as e:
+            print(f"Error updating event: {e}")
+            return None
+
+    # Delete event
+    def delete_event(self, event_id: str) -> bool:
+        try:
+            if self.get_event(event_id)['status'] == 'cancelled':
+                return False
+            
+            self.service.events().delete(calendarId=self.calendar_id, eventId=event_id).execute()
+            return True
+        except HttpError as e:
+            print(f"Error deleting event: {e}")
+            return False

--- a/tests/test_google_calendar_actions.py
+++ b/tests/test_google_calendar_actions.py
@@ -1,0 +1,110 @@
+import pytest
+from agentic_workspace.tools.google_calendar.actions import GoogleCalendar
+
+
+# pytest insert event
+def test_google_calendar_actions():
+    with GoogleCalendar() as calendar:
+        response = calendar.insert_event({
+            'summary': 'Test Event',
+            'description': 'This is a test event',
+            'start': {
+                'dateTime': '2023-05-01T23:00:00+07:00',
+                'timeZone': 'America/New_York'
+            },
+            'end': {
+                'dateTime': '2023-05-01T23:00:00+07:00',
+                'timeZone': 'America/New_York'
+            }
+        })
+
+        assert response is not None
+        assert response['summary'] == 'Test Event'
+        assert response['description'] == 'This is a test event'
+        assert response['start']['dateTime'] == '2023-05-01T23:00:00+07:00'
+        assert response['end']['dateTime'] == '2023-05-01T23:00:00+07:00'
+
+        # delete the event
+        calendar.delete_event(response['id'])
+
+# pytest list event
+def test_google_calendar_list_event():
+    with GoogleCalendar() as calendar:
+        response = calendar.list_event(timeMin='2023-05-01T23:00:00+07:00', maxResults=10)
+        assert response is not None
+        assert len(response) > 0
+
+# pytest get event
+def test_google_calendar_get_event():
+    with GoogleCalendar() as calendar:
+        # insert an event
+        inserted_event = calendar.insert_event({
+            'summary': 'Test Event',
+            'description': 'This is a test event',
+            'start': {
+                'dateTime': '2023-05-01T23:00:00+07:00',
+                'timeZone': 'America/New_York'
+            },
+            'end': {
+                'dateTime': '2023-05-01T23:00:00+07:00',
+                'timeZone': 'America/New_York'
+            }
+        })
+
+        # get the event
+        response = calendar.get_event(inserted_event['id'])
+        assert response is not None
+        assert response['summary'] == 'Test Event'
+        assert response['start']['dateTime'] == '2023-05-01T23:00:00+07:00'
+        assert response['end']['dateTime'] == '2023-05-01T23:00:00+07:00'
+
+        # delete the event
+        calendar.delete_event(inserted_event['id'])
+
+# pytest update event
+def test_google_calendar_update_event():
+    with GoogleCalendar() as calendar:
+        # insert an event
+        inserted_event = calendar.insert_event({
+            'summary': 'Test Event',
+            'description': 'This is a test event',
+            'start': {
+                'dateTime': '2023-05-01T23:00:00+07:00',
+                'timeZone': 'America/New_York'
+            },  
+            'end': {
+                'dateTime': '2023-05-01T23:00:00+07:00',
+                'timeZone': 'America/New_York'
+            }
+        })  
+
+        # update the event
+        response = calendar.update_event(inserted_event['id'], {
+            'summary': 'Updated Event'
+        })
+        assert response is not None
+        assert response['summary'] == 'Updated Event'
+
+        # delete the event
+        calendar.delete_event(inserted_event['id'])
+
+# pytest delete event
+def test_google_calendar_delete_event():
+    with GoogleCalendar() as calendar:
+        # insert an event
+        inserted_event = calendar.insert_event({
+            'summary': 'Test Event',
+            'description': 'This is a test event',
+            'start': {
+                'dateTime': '2023-05-01T23:00:00+07:00',
+                'timeZone': 'America/New_York'
+            },
+            'end': {
+                'dateTime': '2023-05-01T23:00:00+07:00',
+                'timeZone': 'America/New_York'
+            }
+        })
+
+        # delete the event
+        deleted = calendar.delete_event(inserted_event['id'])
+        assert deleted is True


### PR DESCRIPTION
Add Google Calendar API integration and example environment file

This commit introduces a new integration with the Google Calendar API by implementing a class `GoogleCalendar` that supports full CRUD operations for calendar events.

Features included:
- `insert_event`: Create and add a new event to the calendar
- `list_events`: Retrieve a list of upcoming or past events
- `get_event`: Fetch details of a specific event by ID
- `update_event`: Modify the details of an existing event
- `delete_event`: Remove an event from the calendar

Also includes:
- A sample `.env.example` file for setting up required credentials and configuration variables.
